### PR TITLE
Upgrade to net9

### DIFF
--- a/.github/upgrades/dotnet-upgrade-plan.md
+++ b/.github/upgrades/dotnet-upgrade-plan.md
@@ -1,0 +1,58 @@
+# .NET 9.0 Upgrade Plan
+
+## Execution Steps
+
+Execute steps below sequentially one by one in the order they are listed.
+
+1. Validate that an .NET 9.0 SDK required for this upgrade is installed on the machine and if not, help to get it installed.
+2. Ensure that the SDK version specified in global.json files is compatible with the .NET 9.0 upgrade.
+3. Upgrade src/RazorDotnet6/RazorDotnet6.csproj
+4. Upgrade src/APIDotnet6/APIDotnet6.csproj
+
+## Settings
+
+This section contains settings and data used by execution steps.
+
+### Excluded projects
+
+Table below contains projects that do belong to the dependency graph for selected projects and should not be included in the upgrade.
+
+| Project name                                   | Description                 |
+|:-----------------------------------------------|:---------------------------:|
+| (none)                                         |                             |
+
+### Aggregate NuGet packages modifications across all projects
+
+NuGet packages used across all selected projects or their dependencies that need version update in projects that reference them.
+
+| Package Name                                 | Current Version | New Version | Description                        |
+|:---------------------------------------------|:---------------:|:-----------:|:-----------------------------------|
+| Microsoft.EntityFrameworkCore.InMemory       | 6.0.33          | 9.0.9       | Recommended for .NET 9.0           |
+| Microsoft.EntityFrameworkCore.SqlServer      | 6.0.33          | 9.0.9       | Recommended for .NET 9.0           |
+
+### Project upgrade details
+This section contains details about each project upgrade and modifications that need to be done in the project.
+
+#### src/RazorDotnet6/RazorDotnet6.csproj modifications
+
+Project properties changes:
+  - Target framework should be changed from `net6.0` to `net9.0`
+
+NuGet packages changes:
+  - Microsoft.EntityFrameworkCore.InMemory should be updated from `6.0.33` to `9.0.9` (*recommended for .NET 9.0*)
+  - Microsoft.EntityFrameworkCore.SqlServer should be updated from `6.0.33` to `9.0.9` (*recommended for .NET 9.0*)
+
+Other changes:
+  - Review EF Core breaking changes between 6.x and 9.x (query translation, timeouts, logging categories) and adjust code if needed.
+
+#### src/APIDotnet6/APIDotnet6.csproj modifications
+
+Project properties changes:
+  - Target framework should be changed from `net6.0` to `net9.0`
+
+NuGet packages changes:
+  - Microsoft.EntityFrameworkCore.InMemory should be updated from `6.0.33` to `9.0.9` (*recommended for .NET 9.0*)
+  - Microsoft.EntityFrameworkCore.SqlServer should be updated from `6.0.33` to `9.0.9` (*recommended for .NET 9.0*)
+
+Other changes:
+  - Review EF Core breaking changes between 6.x and 9.x (query translation, timeouts, logging categories) and adjust code if needed.

--- a/.github/upgrades/dotnet-upgrade-report.md
+++ b/.github/upgrades/dotnet-upgrade-report.md
@@ -1,0 +1,37 @@
+# .NET 9.0 Upgrade Report
+
+## Project target framework modifications
+
+| Project name                                   | Old Target Framework | New Target Framework | Commits   |
+|:-----------------------------------------------|:--------------------:|:--------------------:|-----------|
+| src/RazorDotnet6/RazorDotnet6.csproj           | net6.0               | net9.0               | b5f7661f  |
+| src/APIDotnet6/APIDotnet6.csproj               | net6.0               | net9.0               | 64642cf5  |
+
+## NuGet Packages
+
+| Package Name                           | Old Version | New Version | Commit Id  |
+|:---------------------------------------|:-----------:|:-----------:|-----------|
+| Microsoft.EntityFrameworkCore.InMemory | 6.0.33      | 9.0.9       | 10d7b995  |
+| Microsoft.EntityFrameworkCore.SqlServer| 6.0.33      | 9.0.9       | 10d7b995  |
+| Microsoft.EntityFrameworkCore.InMemory | 6.0.33      | 9.0.9       | 71319778  |
+| Microsoft.EntityFrameworkCore.SqlServer| 6.0.33      | 9.0.9       | 71319778  |
+
+## All commits
+
+| Commit ID  | Description                                     |
+|:-----------|:------------------------------------------------|
+| 98992baa   | Commit upgrade plan                             |
+| b5f7661f   | Update RazorDotnet6.csproj to target .NET 9.0    |
+| 10d7b995   | Update EF Core packages to 9.0.9 in RazorDotnet6.csproj |
+| 64642cf5   | Update APIDotnet6.csproj to target .NET 9.0      |
+| 71319778   | Update EF Core packages in APIDotnet6.csproj     |
+
+## Project feature upgrades
+
+(No individual feature upgrade sections were required for this plan.)
+
+## Next steps
+
+- Run the solution build and execute any test suites (add tests if missing) to validate runtime behavior.
+- Review EF Core 9 breaking changes: adjust query patterns, logging, and configuration if needed.
+- Monitor application in lower environments for performance or behavioral differences.

--- a/src/APIDotnet6/APIDotnet6.csproj
+++ b/src/APIDotnet6/APIDotnet6.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>

--- a/src/APIDotnet6/APIDotnet6.csproj
+++ b/src/APIDotnet6/APIDotnet6.csproj
@@ -7,8 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="6.0.33" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.33" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.9" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.9" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
   </ItemGroup>
 

--- a/src/RazorDotnet6/RazorDotnet6.csproj
+++ b/src/RazorDotnet6/RazorDotnet6.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>

--- a/src/RazorDotnet6/RazorDotnet6.csproj
+++ b/src/RazorDotnet6/RazorDotnet6.csproj
@@ -7,8 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="6.0.33" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.33" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.9" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.9" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.9" />
   </ItemGroup>
 


### PR DESCRIPTION
This pull request upgrades two projects, `RazorDotnet6` and `APIDotnet6`, from .NET 6.0 to .NET 9.0. It updates their target frameworks and key Entity Framework Core dependencies, and includes documentation of the upgrade plan and a report summarizing the changes. The upgrade also notes the need to review and potentially adjust code for EF Core 9 breaking changes.

**Project and Dependency Upgrades:**

- Upgraded both `src/RazorDotnet6/RazorDotnet6.csproj` and `src/APIDotnet6/APIDotnet6.csproj` target frameworks from `net6.0` to `net9.0`. [[1]](diffhunk://#diff-b12e2e2c1b5a04d4a004a8239c03bef1123eb5745d14e86d8a7908693e854acfL4-R11) [[2]](diffhunk://#diff-8a4d6290f6fdc55bbf7127d8fd89af6cc4107cb4539d4c16eeb2d05aea5380edL4-R11)
- Updated `Microsoft.EntityFrameworkCore.InMemory` and `Microsoft.EntityFrameworkCore.SqlServer` NuGet package versions from `6.0.33` to `9.0.9` in both projects to ensure compatibility with .NET 9.0. [[1]](diffhunk://#diff-b12e2e2c1b5a04d4a004a8239c03bef1123eb5745d14e86d8a7908693e854acfL4-R11) [[2]](diffhunk://#diff-8a4d6290f6fdc55bbf7127d8fd89af6cc4107cb4539d4c16eeb2d05aea5380edL4-R11)

**Documentation and Upgrade Process:**

- Added `.github/upgrades/dotnet-upgrade-plan.md` detailing the step-by-step plan for the .NET 9.0 upgrade, including SDK validation, project and package updates, and notes on reviewing EF Core breaking changes.
- Added `.github/upgrades/dotnet-upgrade-report.md` summarizing the completed upgrade, listing all relevant commits, and providing next steps such as running tests and monitoring for issues.